### PR TITLE
fix: prioritize entries where most senses are "usually kana" when looking up by kana

### DIFF
--- a/src/word-result-sorting.ts
+++ b/src/word-result-sorting.ts
@@ -85,18 +85,36 @@ function getKanaHeadwordType(r: ExtendedKanaEntry, result: WordResult): 1 | 2 {
     return 1;
   }
 
-  // (b) all senses for the entry have a `uk` (usually kana) `misc` field
-  //     and the reading is not marked as `ok` (old kana usage).
+  // (b) most of the English senses for the entry have a `uk` (usually kana)
+  //     `misc` field and the reading is not marked as `ok` (old kana usage).
   //
   // We wanted to make the condition here be just one sense being marked as `uk`
   // but then you get words like `梓` being prioritized when searching for `し`
   // because of one sense out of many being usually kana.
-  if (result.s.every((s) => s.misc?.includes('uk'))) {
+  //
+  // Furthermore, we don't want to require _all_ senses to be marked as `uk` or
+  // else that will mean that 成る fails to be prioritized when searching for
+  // `なる` because one sense out of 11 is not marked as `uk`.
+  if (mostMatchedEnSensesAreUk(result.s)) {
     return 1;
   }
 
   // (c) the headword is marked as `nokanji`
   return r.app === 0 ? 1 : 2;
+}
+
+function mostMatchedEnSensesAreUk(senses: WordResult['s']): boolean {
+  const matchedEnSenses = senses.filter(
+    (s) => s.match && (s.lang === undefined || s.lang === 'en')
+  );
+  if (matchedEnSenses.length === 0) {
+    return false;
+  }
+
+  const ukEnSenseCount = matchedEnSenses.filter((s) =>
+    s.misc?.includes('uk')
+  ).length;
+  return ukEnSenseCount >= matchedEnSenses.length / 2;
 }
 
 export function getPriority(result: WordResult): number {


### PR DESCRIPTION
Without this, when we look up "なる" we'll fail to prioritize the entry
for 成る because 1 of its 11 senses is not marked as "usually kana".

This also ensures we don't consider non-English senses (which don't
have "usually kana" annotations) or unmatched senses.
