### PR TITLE
feat!: support version 5 of kanji data

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@birchill/json-equalish": "^1.1.2",
+    "@birchill/kanji-component-string-utils": "^1.0.1",
     "@birchill/normal-jp": "^1.5.2",
     "idb": "^8.0.0",
     "superstruct": "^2.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@birchill/json-equalish':
         specifier: ^1.1.2
         version: 1.1.2
+      '@birchill/kanji-component-string-utils':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@birchill/normal-jp':
         specifier: ^1.5.2
         version: 1.6.0
@@ -135,6 +138,9 @@ packages:
 
   '@birchill/json-equalish@1.1.2':
     resolution: {integrity: sha512-oXsOtXbuxai0iq8bXZKa0S2AkGEEhigu2WcZUbYwRbv4EtHJvT6jqSg5kNtWeI+6frv7ixIbJbuWP6AbNtj7Sw==}
+
+  '@birchill/kanji-component-string-utils@1.0.1':
+    resolution: {integrity: sha512-2Wc+6n0UZNbmazPzyRuERnOGTEvv+fFsC4ZzbLTOkx83JGmLUAKToNEWjaxZ8sZrXu3VZY8UpqdS/izom2WxiA==}
 
   '@birchill/normal-jp@1.6.0':
     resolution: {integrity: sha512-mYZr4JZElWUwzs8QaOzp9ufi4VzVmi+1ERU+nGb4kSW66s80Te1c88zUx+jnl3RmUzP7Q/WENEvuYNH9+eOPdg==}
@@ -3251,6 +3257,8 @@ snapshots:
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@birchill/json-equalish@1.1.2': {}
+
+  '@birchill/kanji-component-string-utils@1.0.1': {}
 
   '@birchill/normal-jp@1.6.0': {}
 

--- a/src/database.test.ts
+++ b/src/database.test.ts
@@ -12,8 +12,8 @@ use(chaiDateTime);
 
 const VERSION_INFO = {
   kanji: {
-    '4': {
-      major: 4,
+    '5': {
+      major: 5,
       minor: 0,
       patch: 0,
       databaseVersion: '175',
@@ -86,8 +86,8 @@ describe('JpdictIdb', function () {
     fetchMock
       .route('end:version-en.json', VERSION_INFO)
       .route(
-        'end:kanji/en/4.0.0.jsonl',
-        `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
+        'end:kanji/en/5.0.0.jsonl',
+        `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
 `
       )
       .route(
@@ -99,7 +99,7 @@ describe('JpdictIdb', function () {
     await db.update({ series: 'kanji', lang: 'en' });
 
     assert.deepEqual(db.kanji.version, {
-      ...VERSION_INFO.kanji['4'],
+      ...VERSION_INFO.kanji['5'],
       lang: 'en',
     });
     assert.equal(db.kanji.state, 'ok');
@@ -117,8 +117,8 @@ describe('JpdictIdb', function () {
     fetchMock
       .route('end:version-en.json', VERSION_INFO)
       .route(
-        'end:kanji/en/4.0.0.jsonl',
-        `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
+        'end:kanji/en/5.0.0.jsonl',
+        `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
 `
       )
       .route(
@@ -147,8 +147,8 @@ describe('JpdictIdb', function () {
     fetchMock
       .route('end:version-en.json', VERSION_INFO)
       .route(
-        'end:kanji/en/4.0.0.jsonl',
-        `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
+        'end:kanji/en/5.0.0.jsonl',
+        `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
 `
       )
       .route(
@@ -163,7 +163,7 @@ describe('JpdictIdb', function () {
     await Promise.all([firstUpdate, secondUpdate]);
 
     assert.equal(
-      fetchMock.callHistory.calls('end:kanji/en/4.0.0.jsonl').length,
+      fetchMock.callHistory.calls('end:kanji/en/5.0.0.jsonl').length,
       1,
       'Should only fetch things once'
     );
@@ -173,8 +173,8 @@ describe('JpdictIdb', function () {
     fetchMock
       .route('end:version-en.json', VERSION_INFO)
       .route(
-        'end:kanji/en/4.0.0.jsonl',
-        `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
+        'end:kanji/en/5.0.0.jsonl',
+        `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
 `
       )
       .route(
@@ -184,8 +184,8 @@ describe('JpdictIdb', function () {
       )
       .route('end:version-fr.json', VERSION_INFO)
       .route(
-        'end:kanji/fr/4.0.0.jsonl',
-        `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
+        'end:kanji/fr/5.0.0.jsonl',
+        `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
 `
       )
       .route(
@@ -210,8 +210,8 @@ describe('JpdictIdb', function () {
     fetchMock
       .route('end:version-en.json', VERSION_INFO)
       .route(
-        'end:kanji/en/4.0.0.jsonl',
-        `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
+        'end:kanji/en/5.0.0.jsonl',
+        `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
 `
       )
       .route(
@@ -230,7 +230,7 @@ describe('JpdictIdb', function () {
 
     await Promise.all([kanjiUpdate, namesUpdate]);
 
-    assert.equal(db.kanji.version?.major, 4);
+    assert.equal(db.kanji.version?.major, 5);
     assert.equal(db.radicals.version?.major, 4);
     assert.equal(db.names.version?.major, 3);
   });
@@ -264,8 +264,8 @@ describe('JpdictIdb', function () {
     fetchMock
       .route('end:version-en.json', VERSION_INFO)
       .route(
-        'end:kanji/en/4.0.0.jsonl',
-        `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
+        'end:kanji/en/5.0.0.jsonl',
+        `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
 `
       )
       .route(
@@ -362,8 +362,8 @@ describe('JpdictIdb', function () {
     fetchMock
       .route('end:version-en.json', VERSION_INFO)
       .route(
-        'end:kanji/en/4.0.0.jsonl',
-        `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
+        'end:kanji/en/5.0.0.jsonl',
+        `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
 `
       )
       .route(
@@ -392,8 +392,8 @@ describe('JpdictIdb', function () {
     fetchMock
       .route('end:version-en.json', VERSION_INFO)
       .route(
-        'end:kanji/en/4.0.0.jsonl',
-        `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
+        'end:kanji/en/5.0.0.jsonl',
+        `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":0,"format":"full"}
 `
       )
       .route(

--- a/src/database.ts
+++ b/src/database.ts
@@ -16,7 +16,7 @@ import { UpdateState } from './update-state';
 import { update } from './update';
 
 const MAJOR_VERSION: { [series in DataSeries]: number } = {
-  kanji: 4,
+  kanji: 5,
   radicals: 4,
   names: 3,
   words: 2,

--- a/src/download-types.ts
+++ b/src/download-types.ts
@@ -225,8 +225,7 @@ const KanjiDownloadRecordSchema: s.Describe<KanjiDownloadRecord> = s.type({
   misc: MiscSchema,
   st: s.optional(s.string()),
   comp: s.optional(s.string()),
-  var: s.optional(s.array(s.string())),
-  cf: s.optional(s.union([s.string(), s.array(s.string())])),
+  cf: s.optional(s.string()),
 });
 
 export function validateKanjiDownloadRecord(

--- a/src/kanji.ts
+++ b/src/kanji.ts
@@ -8,8 +8,7 @@ export type KanjiRecord = {
   misc: KanjiMiscInfo;
   st?: string;
   comp?: string;
-  var?: Array<string>;
-  cf?: string | Array<string>;
+  cf?: string;
 };
 
 export type KanjiReading = {

--- a/src/query.test.ts
+++ b/src/query.test.ts
@@ -15,8 +15,8 @@ import { NameResult, WordResult } from './result-types';
 
 const VERSION_INFO = {
   kanji: {
-    '4': {
-      major: 4,
+    '5': {
+      major: 5,
       minor: 0,
       patch: 0,
       databaseVersion: '175',
@@ -85,9 +85,9 @@ describe('query', function () {
 
     fetchMock.route('end:version-en.json', VERSION_INFO);
     fetchMock.route(
-      'end:kanji/en/4.0.0.jsonl',
-      `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":1,"format":"full","format":"full"}
-{"c":"引","r":{"py":["yin3"],"on":["イン"],"kun":["ひ.く","ひ.ける"],"na":["いな","ひき","ひけ","びき"]},"m":["pull","tug","jerk","admit","install","quote","refer to"],"rad":{"x":57},"refs":{"nelson_c":1562,"nelson_n":1681,"halpern_njecd":181,"halpern_kkld_2ed":160,"heisig6":1318,"henshall":77,"sh_kk2":216,"kanji_in_context":257,"busy_people":"3.2","kodansha_compact":605,"skip":"1-3-1","sh_desc":"3h1.1","conning":422},"misc":{"sc":4,"gr":2,"freq":218,"jlpt":3,"kk":9,"wk":3,"jlptn":4},"comp":"⼸⼁","var":["057-hen"]}
+      'end:kanji/en/5.0.0.jsonl',
+      `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":1,"format":"full","format":"full"}
+{"c":"引","r":{"py":["yin3"],"on":["イン"],"kun":["ひ.く","ひ.ける"],"na":["いな","ひき","ひけ","びき"]},"m":["pull","tug","jerk","admit","install","quote","refer to"],"rad":{"x":57},"refs":{"nelson_c":1562,"nelson_n":1681,"halpern_njecd":181,"halpern_kkld_2ed":160,"heisig6":1318,"henshall":77,"sh_kk2":216,"kanji_in_context":257,"busy_people":"3.2","kodansha_compact":605,"skip":"1-3-1","sh_desc":"3h1.1","conning":422},"misc":{"sc":4,"gr":2,"freq":218,"jlpt":3,"kk":9,"wk":3,"jlptn":4},"comp":"⼸{057-hen}⼁"}
 `
     );
     fetchMock.route(
@@ -113,15 +113,9 @@ describe('query', function () {
         },
         m: ['pull', 'tug', 'jerk', 'admit', 'install', 'quote', 'refer to'],
         rad: {
-          x: 57,
-          b: '⼸',
-          k: '弓',
-          na: ['ゆみへん'],
-          m: ['bow', 'bow (archery, violin)'],
-          m_lang: 'en',
-          base: {
-            b: '⼸',
-            k: '弓',
+          x: {
+            r: 57,
+            c: '⼸',
             na: ['ゆみ'],
             m: ['bow', 'bow (archery, violin)'],
             m_lang: 'en',
@@ -150,6 +144,14 @@ describe('query', function () {
             na: ['ゆみへん'],
             m: ['bow', 'bow (archery, violin)'],
             m_lang: 'en',
+            base: {
+              c: '⼸',
+              k: '弓',
+              na: ['ゆみ'],
+              m: ['bow', 'bow (archery, violin)'],
+              m_lang: 'en',
+            },
+            is_rad: true,
           },
           {
             c: '⼁',
@@ -172,9 +174,9 @@ describe('query', function () {
 
     fetchMock.route('end:version-en.json', VERSION_INFO);
     fetchMock.route(
-      'end:kanji/en/4.0.0.jsonl',
-      `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":1,"format":"full"}
-{"c":"通","r":{"on":["ツウ","ツ"],"kun":["とお.る","とお.り","-とお.り","-どお.り","とお.す","とお.し","-どお.し","かよ.う"],"na":["とん","どうし","どおり","みち"]},"m":["traffic","pass through","avenue","commute","counter for letters, notes, documents, etc."],"rad":{"x":162},"refs":{"nelson_c":4703,"nelson_n":6063,"halpern_njecd":3109,"halpern_kkld":1982,"halpern_kkld_2ed":2678,"heisig":1408,"heisig6":1511,"henshall":176,"sh_kk":150,"sh_kk2":150,"kanji_in_context":204,"busy_people":"3.11","kodansha_compact":695,"skip":"3-3-7","sh_desc":"2q7.18","conning":159},"misc":{"sc":9,"gr":2,"freq":80,"jlpt":3,"kk":9},"comp":"マ⽤⻌","var":["162-nyou"]}
+      'end:kanji/en/5.0.0.jsonl',
+      `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":1,"format":"full"}
+{"c":"通","r":{"on":["ツウ","ツ"],"kun":["とお.る","とお.り","-とお.り","-どお.り","とお.す","とお.し","-どお.し","かよ.う"],"na":["とん","どうし","どおり","みち"]},"m":["traffic","pass through","avenue","commute","counter for letters, notes, documents, etc."],"rad":{"x":162},"refs":{"nelson_c":4703,"nelson_n":6063,"halpern_njecd":3109,"halpern_kkld":1982,"halpern_kkld_2ed":2678,"heisig":1408,"heisig6":1511,"henshall":176,"sh_kk":150,"sh_kk2":150,"kanji_in_context":204,"busy_people":"3.11","kodansha_compact":695,"skip":"3-3-7","sh_desc":"2q7.18","conning":159},"misc":{"sc":9,"gr":2,"freq":80,"jlpt":3,"kk":9},"comp":"マ⽤⻌"}
 `
     );
     fetchMock.route(
@@ -210,6 +212,14 @@ describe('query', function () {
         na: ['しんにょう', 'しんにゅう'],
         m: ['road', 'walk', 'to advance', 'move ahead'],
         m_lang: 'en',
+        base: {
+          c: '⾡',
+          k: '辵',
+          na: ['しんにょう', 'しんにゅう'],
+          m: ['road', 'walk', 'to advance', 'move ahead'],
+          m_lang: 'en',
+        },
+        is_rad: true,
       },
     ]);
   });
@@ -219,10 +229,10 @@ describe('query', function () {
 
     fetchMock.route('end:version-en.json', VERSION_INFO);
     fetchMock.route(
-      'end:kanji/en/4.0.0.jsonl',
-      `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":2,"format":"full"}
+      'end:kanji/en/5.0.0.jsonl',
+      `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":2,"format":"full"}
 {"c":"凶","r":{"on":["キョウ"]},"m":["villain","evil","bad luck","disaster"],"rad":{"x":17},"refs":{"nelson_c":663,"nelson_n":442,"halpern_njecd":2961,"halpern_kkld":1877,"halpern_kkld_2ed":2557,"heisig":1490,"heisig6":1603,"henshall":1159,"sh_kk":1280,"sh_kk2":1354,"kanji_in_context":1812,"kodansha_compact":172,"skip":"3-2-2","sh_desc":"0a4.19","conning":296},"misc":{"sc":4,"gr":8,"freq":1673,"jlpt":1,"kk":4},"comp":"⼂⼃⼐"}
-{"c":"胸","r":{"on":["キョウ"],"kun":["むね","むな-"]},"m":["bosom","breast","chest","heart","feelings"],"rad":{"x":130},"refs":{"nelson_c":3768,"nelson_n":4811,"halpern_njecd":951,"halpern_kkld":647,"halpern_kkld_2ed":858,"heisig":1491,"heisig6":1604,"henshall":840,"sh_kk":1283,"sh_kk2":1357,"kanji_in_context":1086,"kodansha_compact":1030,"skip":"1-4-6","sh_desc":"4b6.9","conning":1971},"misc":{"sc":10,"gr":6,"freq":1144,"jlpt":2,"kk":5},"comp":"⽉⼓凶","var":["130-2"]}
+{"c":"胸","r":{"on":["キョウ"],"kun":["むね","むな-"]},"m":["bosom","breast","chest","heart","feelings"],"rad":{"x":130},"refs":{"nelson_c":3768,"nelson_n":4811,"halpern_njecd":951,"halpern_kkld":647,"halpern_kkld_2ed":858,"heisig":1491,"heisig6":1604,"henshall":840,"sh_kk":1283,"sh_kk2":1357,"kanji_in_context":1086,"kodansha_compact":1030,"skip":"1-4-6","sh_desc":"4b6.9","conning":1971},"misc":{"sc":10,"gr":6,"freq":1144,"jlpt":2,"kk":5},"comp":"⽉{130-2}⼓凶"}
 `
     );
     fetchMock.route(
@@ -245,13 +255,13 @@ describe('query', function () {
         r: { on: ['キョウ'], kun: ['むね', 'むな-'] },
         m: ['bosom', 'breast', 'chest', 'heart', 'feelings'],
         rad: {
-          x: 130,
-          b: '⽉',
-          k: '月',
-          na: ['にくづき'],
-          m: ['meat'],
-          m_lang: 'en',
-          base: { b: '⾁', k: '肉', na: ['にく'], m: ['meat'], m_lang: 'en' },
+          x: {
+            r: 130,
+            c: '⾁',
+            na: ['にく'],
+            m: ['meat'],
+            m_lang: 'en',
+          },
         },
         refs: {
           nelson_c: 3768,
@@ -272,7 +282,21 @@ describe('query', function () {
         },
         misc: { sc: 10, gr: 6, freq: 1144, jlpt: 2, kk: 5 },
         comp: [
-          { c: '⽉', k: '肉', na: ['にくづき'], m: ['meat'], m_lang: 'en' },
+          {
+            c: '⽉',
+            k: '肉',
+            na: ['にくづき'],
+            m: ['meat'],
+            m_lang: 'en',
+            base: {
+              c: '⾁',
+              k: '肉',
+              na: ['にく'],
+              m: ['meat'],
+              m_lang: 'en',
+            },
+            is_rad: true,
+          },
           {
             c: '⼓',
             k: '勹',
@@ -300,9 +324,9 @@ describe('query', function () {
 
     fetchMock.route('end:version-en.json', VERSION_INFO);
     fetchMock.route(
-      'end:kanji/en/4.0.0.jsonl',
-      `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":1,"format":"full"}
-{"c":"筋","r":{"on":["キン"],"kun":["すじ"]},"m":["muscle","sinew","tendon","fiber","plot","plan","descent"],"rad":{"x":118},"refs":{"nelson_c":3395,"nelson_n":4286,"halpern_njecd":2678,"halpern_kkld":1719,"halpern_kkld_2ed":2337,"heisig":941,"heisig6":1012,"henshall":843,"sh_kk":1090,"sh_kk2":1141,"kanji_in_context":1059,"kodansha_compact":1476,"skip":"2-6-6","sh_desc":"6f6.4","conning":392},"misc":{"sc":12,"gr":6,"freq":744,"jlpt":1,"kk":5},"comp":"⺮⽉⼒","var":["118-kanmuri","130-2"]}
+      'end:kanji/en/5.0.0.jsonl',
+      `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":1,"format":"full"}
+{"c":"筋","r":{"on":["キン"],"kun":["すじ"]},"m":["muscle","sinew","tendon","fiber","plot","plan","descent"],"rad":{"x":118},"refs":{"nelson_c":3395,"nelson_n":4286,"halpern_njecd":2678,"halpern_kkld":1719,"halpern_kkld_2ed":2337,"heisig":941,"heisig6":1012,"henshall":843,"sh_kk":1090,"sh_kk2":1141,"kanji_in_context":1059,"kodansha_compact":1476,"skip":"2-6-6","sh_desc":"6f6.4","conning":392},"misc":{"sc":12,"gr":6,"freq":744,"jlpt":1,"kk":5},"comp":"⺮{118-kanmuri}⽉{130-2}⼒"}
 `
     );
     fetchMock.route(
@@ -327,13 +351,13 @@ describe('query', function () {
         r: { on: ['キン'], kun: ['すじ'] },
         m: ['muscle', 'sinew', 'tendon', 'fiber', 'plot', 'plan', 'descent'],
         rad: {
-          x: 118,
-          b: '⺮',
-          k: undefined,
-          na: ['たけかんむり'],
-          m: ['bamboo'],
-          m_lang: 'en',
-          base: { b: '⽵', k: '竹', na: ['たけ'], m: ['bamboo'], m_lang: 'en' },
+          x: {
+            r: 118,
+            c: '⽵',
+            na: ['たけ'],
+            m: ['bamboo'],
+            m_lang: 'en',
+          },
         },
         refs: {
           nelson_c: 3395,
@@ -360,8 +384,29 @@ describe('query', function () {
             na: ['たけかんむり'],
             m: ['bamboo'],
             m_lang: 'en',
+            base: {
+              c: '⽵',
+              k: '竹',
+              na: ['たけ'],
+              m: ['bamboo'],
+              m_lang: 'en',
+            },
+            is_rad: true,
           },
-          { c: '⽉', k: '肉', na: ['にくづき'], m: ['meat'], m_lang: 'en' },
+          {
+            c: '⽉',
+            k: '肉',
+            na: ['にくづき'],
+            m: ['meat'],
+            m_lang: 'en',
+            base: {
+              c: '⾁',
+              k: '肉',
+              na: ['にく'],
+              m: ['meat'],
+              m_lang: 'en',
+            },
+          },
           {
             c: '⼒',
             k: '力',
@@ -383,14 +428,14 @@ describe('query', function () {
 
     fetchMock.route('end:version-en.json', VERSION_INFO);
     fetchMock.route(
-      'end:kanji/en/4.0.0.jsonl',
-      `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":6,"format":"full"}
-{"c":"構","r":{"py":["gou4"],"on":["コウ"],"kun":["かま.える","かま.う"],"na":["とち"]},"m":["posture","build","pretend"],"rad":{"x":75},"refs":{"nelson_c":2343,"nelson_n":2823,"halpern_njecd":1049,"halpern_kkld_2ed":962,"heisig6":1959,"henshall":675,"sh_kk2":1048,"kanji_in_context":991,"kodansha_compact":1108,"skip":"1-4-10","sh_desc":"4a10.10","conning":917},"misc":{"sc":14,"gr":5,"freq":316,"jlpt":2,"kk":6},"comp":"⽊冓","var":["075-hen"],"cf":"講"}
+      'end:kanji/en/5.0.0.jsonl',
+      `{"type":"header","version":{"major":5,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":6,"format":"full"}
+{"c":"構","r":{"py":["gou4"],"on":["コウ"],"kun":["かま.える","かま.う"],"na":["とち"]},"m":["posture","build","pretend"],"rad":{"x":75},"refs":{"nelson_c":2343,"nelson_n":2823,"halpern_njecd":1049,"halpern_kkld_2ed":962,"heisig6":1959,"henshall":675,"sh_kk2":1048,"kanji_in_context":991,"kodansha_compact":1108,"skip":"1-4-10","sh_desc":"4a10.10","conning":917},"misc":{"sc":14,"gr":5,"freq":316,"jlpt":2,"kk":6},"comp":"⽊{075-hen}冓","cf":"講"}
 {"c":"留","r":{"py":["liu2"],"on":["リュウ","ル"],"kun":["と.める","と.まる","とど.める","とど.まる","るうぶる"],"na":["とめ"]},"m":["detain","fasten","halt","stop"],"rad":{"x":102},"refs":{"nelson_c":3003,"nelson_n":3750,"halpern_njecd":2580,"halpern_kkld_2ed":2235,"heisig6":1527,"henshall":805,"sh_kk2":774,"kanji_in_context":432,"kodansha_compact":1341,"skip":"2-5-5","sh_desc":"5f5.4","conning":1170},"misc":{"sc":10,"gr":5,"freq":731,"jlpt":2,"kk":6},"comp":"⼛⼑⽥","cf":"貿溜"}
 {"c":"冓","r":{"py":["gou4"],"on":["コウ"],"kun":["かま.える"]},"m":["put together","inner palace"],"rad":{"x":13},"refs":{"nelson_n":396,"skip":"2-5-5","sh_desc":"0a10.14"},"misc":{"sc":10,"kk":1},"comp":"井再⼌"}
-{"c":"講","r":{"py":["jiang3"],"on":["コウ"]},"m":["lecture","club","association"],"rad":{"x":149},"refs":{"nelson_c":4425,"nelson_n":5689,"halpern_njecd":1619,"halpern_kkld_2ed":1463,"heisig6":1957,"henshall":676,"sh_kk2":797,"kanji_in_context":495,"kodansha_compact":1707,"skip":"1-7-10","sh_desc":"7a10.3","conning":918},"misc":{"sc":17,"gr":5,"freq":653,"jlpt":2,"kk":6},"comp":"訁冓井再⼌","var":["149-hen"],"cf":"構"}
+{"c":"講","r":{"py":["jiang3"],"on":["コウ"]},"m":["lecture","club","association"],"rad":{"x":149},"refs":{"nelson_c":4425,"nelson_n":5689,"halpern_njecd":1619,"halpern_kkld_2ed":1463,"heisig6":1957,"henshall":676,"sh_kk2":797,"kanji_in_context":495,"kodansha_compact":1707,"skip":"1-7-10","sh_desc":"7a10.3","conning":918},"misc":{"sc":17,"gr":5,"freq":653,"jlpt":2,"kk":6},"comp":"訁冓井再⼌","cf":"構"}
 {"c":"貿","r":{"py":["mao4"],"on":["ボウ"]},"m":["trade","exchange"],"rad":{"x":154},"refs":{"nelson_c":4499,"nelson_n":5788,"halpern_njecd":2601,"halpern_kkld_2ed":2255,"heisig6":1529,"henshall":792,"sh_kk2":773,"kanji_in_context":433,"kodansha_compact":1733,"skip":"2-5-7","sh_desc":"7b5.8","conning":1169},"misc":{"sc":12,"gr":5,"freq":652,"jlpt":2,"kk":6},"comp":"⼛⼑⾙","cf":"留"}
-{"c":"溜","r":{"py":["liu1","liu4"],"on":["リュウ"],"kun":["た.まる","たま.る","た.める","したた.る","たまり","ため"]},"m":["collect","gather","be in arrears"],"rad":{"x":85},"refs":{"nelson_c":2658,"nelson_n":3276,"halpern_njecd":662,"halpern_kkld_2ed":608,"heisig6":2415,"skip":"1-3-10","sh_desc":"3a10.11","conning":1171},"misc":{"sc":13,"gr":9,"freq":2451,"kk":15},"comp":"⺡留⼛⼑⽥","var":["085-hen"]}
+{"c":"溜","r":{"py":["liu1","liu4"],"on":["リュウ"],"kun":["た.まる","たま.る","た.める","したた.る","たまり","ため"]},"m":["collect","gather","be in arrears"],"rad":{"x":85},"refs":{"nelson_c":2658,"nelson_n":3276,"halpern_njecd":662,"halpern_kkld_2ed":608,"heisig6":2415,"skip":"1-3-10","sh_desc":"3a10.11","conning":1171},"misc":{"sc":13,"gr":9,"freq":2451,"kk":15},"comp":"⺡留⼛⼑⽥"}
 `
     );
     fetchMock.route(
@@ -436,53 +481,6 @@ describe('query', function () {
         m: ['collect', 'gather', 'be in arrears'],
         m_lang: 'en',
         misc: { sc: 13, gr: 9, freq: 2451, kk: 15 },
-      },
-    ]);
-  });
-
-  it('should handle an array of related kanji', async () => {
-    await db.ready;
-
-    fetchMock.route('end:version-en.json', VERSION_INFO);
-    // It just so happens that the following data is wrong in that the cf field
-    // refers to itself. We'll fix that upstream but for now it's probably fine
-    // to leave this here as a test we don't get all infinitely recursive.
-    fetchMock.route(
-      'end:kanji/en/4.0.0.jsonl',
-      `{"type":"header","version":{"major":4,"minor":0,"patch":0,"databaseVersion":"175","dateOfCreation":"2019-07-09"},"records":2,"format":"full"}
-{"c":"復","r":{"py":["fu4"],"on":["フク"],"kun":["また"]},"m":["restore","return to","revert","resume"],"rad":{"x":60},"refs":{"nelson_c":1627,"nelson_n":1760,"halpern_njecd":575,"halpern_kkld_2ed":527,"heisig6":940,"henshall":782,"sh_kk2":939,"kanji_in_context":521,"kodansha_compact":634,"skip":"1-3-9","sh_desc":"3i9.4","conning":865},"misc":{"sc":12,"gr":5,"freq":438,"jlpt":2,"kk":6,"jlptn":2},"comp":"⼻复⽇⼡","cf":["複","輹"]}
-{"c":"複","r":{"py":["fu4"],"on":["フク"]},"m":["duplicate","double","compound","multiple"],"rad":{"x":145},"refs":{"nelson_c":4255,"nelson_n":5484,"halpern_njecd":1222,"halpern_kkld_2ed":1132,"heisig6":504,"henshall":783,"sh_kk2":938,"kanji_in_context":522,"kodansha_compact":1636,"skip":"1-5-9","sh_desc":"5e9.3","conning":863},"misc":{"sc":14,"gr":5,"freq":915,"jlpt":2,"kk":6,"jlptn":2},"comp":"⻂复⽇⼡","var":["145-hen"],"cf":["復","複"]}
-`
-    );
-    fetchMock.route(
-      'end:radicals/en/4.0.0.jsonl',
-      `{"type":"header","version":{"major":4,"minor":0,"patch":0,"dateOfCreation":"2019-09-06"},"records":4,"format":"full"}
-{"id":"034","r":34,"b":"⼡","k":"夂","s":3,"na":["ふゆがしら","のまたかんむり","のまた","ちかんむり"],"m":["winter"]}
-{"id":"072","r":72,"b":"⽇","k":"日","s":4,"na":["ひ"],"m":["day","sun","Japan","counter for days"]}
-{"id":"145","r":145,"b":"⾐","k":"衣","s":6,"na":["ころも"],"m":["garment","clothes","dressing"]}
-{"id":"145-hen","r":145,"b":"⻂","k":"衤","s":5,"na":["ころもへん"],"m":["garment","clothes","dressing"],"posn":"hen"}
-`
-    );
-
-    await db.update({ series: 'kanji', lang: 'en' });
-
-    const result = await getKanji({ kanji: ['複'], lang: 'en' });
-
-    assert.lengthOf(result, 1);
-    assert.deepEqual(result[0].cf, [
-      {
-        c: '復',
-        r: { py: ['fu4'], on: ['フク'], kun: ['また'] },
-        m: ['restore', 'return to', 'revert', 'resume'],
-        m_lang: 'en',
-        misc: { sc: 12, gr: 5, freq: 438, jlpt: 2, kk: 6, jlptn: 2 },
-      },
-      {
-        c: '複',
-        r: { py: ['fu4'], on: ['フク'] },
-        m: ['duplicate', 'double', 'compound', 'multiple'],
-        m_lang: 'en',
-        misc: { sc: 14, gr: 5, freq: 915, jlpt: 2, kk: 6, jlptn: 2 },
       },
     ]);
   });

--- a/src/result-types.ts
+++ b/src/result-types.ts
@@ -1,4 +1,4 @@
-import { KanjiMiscInfo, KanjiReading, Radical } from './kanji';
+import { KanjiMiscInfo, KanjiReading } from './kanji';
 import { NameRecord } from './names';
 import { Overwrite, Resolve } from './type-helpers';
 import { GlossType, KanjiMeta, ReadingMeta, WordSense } from './words';
@@ -76,41 +76,58 @@ export type KanjiResult = {
   refs: Record<string, string | number>;
   misc: KanjiMiscInfo;
   st?: string;
-  comp: Array<{
-    c: string;
-    na: Array<string>;
-    // An optional field indicating the kanji character to link to.
-    //
-    // For example, if the component is ⺮, one might want to look up other
-    // kanji with that component, but they also might want to look up the
-    // corresponding kanji for the component, i.e. 竹.
-    //
-    // For kanji / katakana components this is empty. For radical components
-    // this is the kanji of the base radical, if any.
-    k?: string;
-    m: Array<string>;
-    m_lang: string;
-  }>;
+  comp: Array<KanjiComponentInfo & { sub?: Array<KanjiComponentInfo> }>;
   var?: Array<string>;
   cf: Array<RelatedKanji>;
 };
 
-export type ExpandedRadical = Resolve<
-  Omit<Radical, 'name'> & {
-    b?: string;
-    k?: string;
+export type KanjiComponentFields = {
+  /** The character for this component */
+  c: string;
+  /** The name(s) of this component */
+  na: Array<string>;
+  /**
+   * An optional field indicating the kanji character to link to.
+   *
+   * For example, if the component is ⺮, one might want to look up other
+   * kanji with that component, but they also might want to look up the
+   * corresponding kanji for the component, i.e. 竹.
+   *
+   * For kanji / katakana components this is empty. For radical components
+   * this is the kanji of the base radical, if any.
+   */
+  k?: string;
+  /** Meaning of the component */
+  m: Array<string>;
+  /** The language of the meanings in the `m` field */
+  m_lang: string;
+};
+
+export type KanjiComponentInfo = KanjiComponentFields & {
+  base?: KanjiComponentFields;
+  /**
+   * True if this component is the kanji's radical (and not simply because
+   * the component was found in the radical data).
+   */
+  is_rad?: boolean;
+};
+
+export type ExpandedRadical = {
+  x: {
+    r: number;
+    c: string;
     na: Array<string>;
     m: Array<string>;
     m_lang: string;
-    base?: {
-      b?: string;
-      k?: string;
-      na: Array<string>;
-      m: Array<string>;
-      m_lang: string;
-    };
-  }
->;
+  };
+  nelson?: {
+    r: number;
+    c: string;
+    na: Array<string>;
+    m: Array<string>;
+    m_lang: string;
+  };
+};
 
 export type RelatedKanji = {
   c: string;

--- a/src/update-with-retry.test.ts
+++ b/src/update-with-retry.test.ts
@@ -15,7 +15,7 @@ const fastSetTimeout = (cb: () => void) => {
 
 const VERSION_INFO = {
   kanji: {
-    '4': {
+    '5': {
       major: 4,
       minor: 0,
       patch: 0,


### PR DESCRIPTION
BREAKING CHANGE: The type of `KanjiResult['comp']` has been updated to
support nested kanji components.

BREAKING CHANGE: The type of `KanjiResult['rad']` to simplify the
fields. Whether or not a component is the radical is determined by the
`is_rad` field on `KanjiResult['comp']`.
